### PR TITLE
import from charmbox:latest instead of :devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jujusolutions/charmbox:devel
+FROM jujusolutions/charmbox:latest
 
 RUN git clone https://github.com/juju-solutions/cloud-weather-report.git /home/ubuntu/cloud-weather-report
 RUN pip2 install -r /home/ubuntu/cloud-weather-report/requirements.txt


### PR DESCRIPTION
Jujubox and charmbox have been updated so the latest builds track the stable releases of juju2. cwrbox is based on `charmbox:devel`, which will soon switch to juju-2.1-beta1. To ensure cwr is using a stable juju release, update the Dockerfile to base off of `charmbox:latest`.